### PR TITLE
Set default version to recent PyPI instead of `main` branch

### DIFF
--- a/.github/workflows/test_action.yml
+++ b/.github/workflows/test_action.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           library_name: "Test"
           schema_path: "./.github/workflows/model.md"
-          output_dir: "./.github/workflows/"
+          out_dir: "./.github/workflows/"
           push: "false"
       - name: Test
         run: |

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,8 @@ inputs:
     required: true
     default: "./"
   branch:
-    description: "The sdRDM branch to be used for the generated API."
-    required: true
-    default: "main"
+    description: "The sdRDM branch to be used for the generated API. Meant for dev purposes. Standard installaton uses the latest pip release."
+    required: false
   push:
     description: "Push the generated API to the specified branch."
     required: true
@@ -44,30 +43,12 @@ runs:
       run: |
         printf "::group::🔧 Installing dependencies\n"
 
-        python -m pip install git+https://github.com/JR-1991/software-driven-rdm.git@${{ inputs.branch }}
-
-        printf "::endgroup::\n"
-
-        printf "::group::🤖 Generating sdRDM API\n"
-        
-        sdrdm generate \
-          --path "${{ inputs.schema_path }}" \
-          --out "${{ inputs.out_dir }}" \
-          --name "${{ inputs.library_name }}" \
-          --url "${{ github.server_url }}/${{ github.repository }}" \
-          --commit "${{ github.sha }}"
-
-        printf "::endgroup::\n"
-
-        if [[ ${{ inputs.schema }} == 'true' ]]; then
-          printf "::group::🤖 Generating sdRDM schema\n"
-          
-          sdrdm schema \
-            --path "${{ inputs.schema_path }}" \
-            --out "${{ inputs.schema_out_dir }}" \
-            --name "${{ inputs.library_name }}" \
-
-          printf "::endgroup::\n"
+        if [[ -n "${{ inputs.branch }}" ]]; then
+          printf "::group::🔧 Installing dependencies\n"
+          python -m pip install git+https://github.com/JR-1991/software-driven-rdm.git@${{ inputs.branch }}
+        else
+          printf "::group::🔧 Installing dependencies\n"
+          python -m pip install sdrdm
         fi
     - name: "Pushing API"
       if: ${{ inputs.push == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,16 @@ runs:
           printf "::group::🔧 Installing dependencies\n"
           python -m pip install sdrdm
         fi
+
+        sdrdm generate \
+          --path "${{ inputs.schema_path }}" \
+          --out "${{ inputs.out_dir }}" \
+          --name "${{ inputs.library_name }}" \
+          --url "${{ github.server_url }}/${{ github.repository }}" \
+          --commit "${{ github.sha }}"
+
+        printf "✅ Done\n"
+        printf "::endgroup::\n"
     - name: "Pushing API"
       if: ${{ inputs.push == 'true' }}
       shell: "bash"


### PR DESCRIPTION
By default, the API will be generated from the recent PyPI version.